### PR TITLE
Fix CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ node_js:
   - "11"
   - "10"
   - "8"
-install: lerna bootstrap
+install: npx lerna bootstrap
 script: yarn lint && yarn test && yarn report-coverage

--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ These tools require an account with at least one of these (paid) services:
 
 Pull requests and suggestions are welcome. [Create a new issue](https://github.com/eheikes/tts/issues/new) to report a bug or suggest a new feature.
 
+Development commands:
+
+```
+npx lerna bootstrap   # download the project dependencies
+lerna run lint        # lint code
+lerna run test        # run tests
+```

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/eheikes/tts#readme",
   "scripts": {
     "lint": "lerna run lint",
-    "postinstall": "lerna bootstrap",
     "report-coverage": "lerna run report-coverage",
     "test": "lerna run test"
   },


### PR DESCRIPTION
lerna doesn't exist prior to dep installation.

Also, if the packages are installed through `lerna bootstrap`, there's no reason to run it postinstall.